### PR TITLE
Add SAD role to common area user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /bin/
 .classpath
 .project
+.idea
+

--- a/custom-migrations/auth/V9__ADD_SAD_ROLE_TO_INST_USER.sql
+++ b/custom-migrations/auth/V9__ADD_SAD_ROLE_TO_INST_USER.sql
@@ -1,0 +1,12 @@
+use auth;
+
+-- The GIC institute nodes have a special user called CommonAreaUser that the common area uses to run federated queries.
+-- This user now needs the ability to run these queries, so we add them to the Secret Admin Dataframe role
+
+-- We're ignoring duplicate key errors (the constraint will still be enforced) to handle institutes that already
+-- upgraded and did this manually.
+INSERT IGNORE INTO user_role (user_id, role_id)
+	VALUES (
+	    (SELECT uuid FROM user WHERE email = 'CommonAreaUser'),
+	    (SELECT uuid FROM role WHERE name = 'PIC-SURE Secret Dataframe Requester')
+    );


### PR DESCRIPTION
- The common area user is a special user that the common area uses to run queries on the institute node
- This gives that user the permissions to run, but not view queries